### PR TITLE
add example for  --short

### DIFF
--- a/logic/subuserCommands/list
+++ b/logic/subuserCommands/list
@@ -13,7 +13,8 @@ def printHelp():
  $ subuser list available
 
   The list available command may optionally take the `--short` argument which will print only the program's names.
-
+  $ subuser list available --short
+  
 Or you can list installed programs with:
  $ subuser list installed
 """)


### PR DESCRIPTION
First it did not seem to work because I used: subuser list --short available

so adding an example would be good
