### PR TITLE
changed typo: uneeded to unneeded?

### DIFF
--- a/logic/subuserCommands/clean
+++ b/logic/subuserCommands/clean
@@ -8,22 +8,22 @@ import subuserlib.permissions
 
 ####################################################
 def printHelp():
- print(""" Clean your system of uneeded images/libaries/executable-less programs.  If a libarary has no programs depending on it, uninstall that libarary.  Run this command with:
+ print(""" Clean your system of unneeded images/libaries/executable-less programs.  If a libarary has no programs depending on it, uninstall that libarary.  Run this command with:
 
 $ subuser clean
 """)
 
-def gatherUneededLibs():
- """ Returns a list of uneeded libaries. """
+def gatherUnneededLibs():
+ """ Returns a list of unneeded libaries. """
  installedPrograms = subuserlib.registry.getInstalledPrograms()
- uneededLibs = []
+ unneededLibs = []
  for program,lastUpdateTime in installedPrograms.iteritems():
   if not subuserlib.permissions.hasExecutable(program) and not subuserlib.registry.hasInstalledDependencies(program):
-   uneededLibs.append(program)
- return uneededLibs
+   unneededLibs.append(program)
+ return unneededLibs
  
-def cleanUneededLibs():
- programsToUninstall = gatherUneededLibs()
+def cleanUnneededLibs():
+ programsToUninstall = gatherUnneededLibs()
  if len(programsToUninstall) > 0:
   performUninstalls(programsToUninstall)
  else:
@@ -41,4 +41,4 @@ def performUninstalls(programsToUninstall):
 if len(sys.argv) > 1:
  printHelp()
 else:
- cleanUneededLibs() 
+ cleanUnneededLibs() 


### PR DESCRIPTION
changed typo: uneeded to unneeded

hi sorry for that:English is not my first language.

I came across the clean.py and saw `uneeded` which I do not recall and my spellcheck also marks - I only know `unneeded`

https://github.com/subuser-security/subuser/blob/master/logic/subuserCommands/clean#L16

so I did some google search: `uneeded vs. unneeded`

Seems in  official dictionaries `unneeded`  but otherwise your version also comes up.

is this street language?  anyway if you want to change it to what spellchecks suggest: I did a patch otherwise just close it.
