### PR TITLE
* Implemented: logon to interactive shell with permission entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 VERSION 0.2
 -------------
 
+* Implemented: logon to interactive shell with permission entry (e.g. firefox)
+  issue #55, also simplified unneeded function code: issue #56
+  
 * Refactor some print statements
   issue #51
   

--- a/logic/subuserCommands/run
+++ b/logic/subuserCommands/run
@@ -14,10 +14,16 @@ cwd = os.getcwd()
 home = os.path.expanduser("~")
 ###############################################################
 def printHelp():
- print("""Run a program installed with subuser.  For example:
-$ subuser run firefox
+ print("""Run a program installed with subuser.  For example: subuser run firefox [optional arguments to be pass on to the program]
+$ subuser run firefox 
+$ subuser run firefox  -new-instance -safe-mode
 
 This command is useful if you want to put `~/subuser/bin` at the end of your path.  If you do that, subuser programs will not have precidence over "normally" installed programs.
+
+The 'run' command may optionally take the a special single argument: `--container` which will logon to an interactive shell (new container of a subuser program)
+  $ subuser run firefox --container
+  
+The command option '--container' is useful if you want to inspect on a shell basis the program container and is similar to the docker comand: 'docker run -i -t subuser-program-name path-to-shell'
 """)
 
 def getArgsToPassToProgram():
@@ -50,6 +56,19 @@ def makeUserDirVolumeArgs(userDirs):
 def runProgram(programName):
  dockerImageName = subuserlib.dockerImages.getImageTagOfInstalledProgram(programName)
 
+ #CHECK: interactiveContainerLogon
+ try:
+  if sys.argv[2] == "--container":
+   if subuserlib.permissions.hasShell(programName):
+    pathToShelll = subuserlib.permissions.getPermissions(programName)["path-to-shell"]
+    dockerCommand = ["docker","run","-i","-t","-rm",dockerImageName,pathToShelll]
+    subprocess.call(dockerCommand)
+   else:
+    print("<%s> has no permission to logon to shell" % programName)
+   sys.exit()
+ except IndexError:
+  pass
+  
  args=getArgsToPassToProgram()
 
  permissions = subuserlib.permissions.getPermissions(programName)
@@ -99,17 +118,14 @@ def runProgram(programName):
  except KeyError:
   systemDirVolumeArgs = []
 
- def setupUserDirSymlinks(userDirs):
-  """ Create symlinks to userdirs in program's home dir. """
+ try:
+  userDirs = permissions["user-dirs"]
+  #Create symlinks to userdirs in program's home dir.
   for userDir in userDirs:
    source = os.path.join("/userdirs/",userDir)
    destination = os.path.join(hostSubuserHome,userDir)
    if not os.path.islink(destination):
     os.symlink(source,destination)
-
- try:
-  userDirs = permissions["user-dirs"]
-  setupUserDirSymlinks(userDirs)
   userDirVolumeArgs = makeUserDirVolumeArgs(userDirs)
  except KeyError:
   userDirVolumeArgs = []

--- a/logic/subuserCommands/subuserlib/permissions.py
+++ b/logic/subuserCommands/subuserlib/permissions.py
@@ -29,3 +29,11 @@ def hasExecutable(programName):
   return True
  except KeyError:
   return False
+ 
+def hasShell(programName):
+ """ Return True if the program has an shell for interactive logon associated with it. """
+ try:
+  getPermissions(programName)["path-to-shell"]
+  return True
+ except KeyError:
+  return False

--- a/programsThatCanBeInstalled/firefox/permissions.json
+++ b/programsThatCanBeInstalled/firefox/permissions.json
@@ -10,5 +10,6 @@
  ,"sound"                     : true
  ,"inherit-working-directory" : false
  ,"allow-network-access"      : true
+ ,"path-to-shell"             : "/bin/bash"
 }
 


### PR DESCRIPTION
- Implemented: logon to interactive shell with permission entry (e.g. firefox)
  
  issue #55, also simplified unneeded function code: issue #56

Also added a note/example that one can pass on arguments to `subuser run programs`   I did not know that before

e.g. with permission set

```
workerm@notebook:~$ subuser run firefox --container
root@cb31ffe9fb16:/# 
```

No permission set (default)

```
workerm@notebook:~$ subuser run libx11 --container
<libx11> has no permission to logon to shell
workerm@notebook:~$ 
```
