### PR TITLE
* Implemented install-from-registry command which installs all of the pr...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 VERSION 0.2
 -------------
 
+* Implemented install-from-registry command which installs all of the programs listed in installed-programs.json file. #23
+
 * Refactor some print statements
   issue #51
   

--- a/logic/subuserCommands/install-from-registry
+++ b/logic/subuserCommands/install-from-registry
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+# This file should be compatible with both Python 2 and 3.
+# If it is not, please file a bug report.
+import sys
+import subuserlib.utils
+import subuserlib.registry
+
+####################################################
+def printHelp():
+ print(""" <install-from-registry> command which installs all of the programs listed in installed-programs.json file.  Run this command with:
+
+$ subuser install-from-registry
+
+Options:
+ --from-cache similar to the `install` command: build images using layers from the cache if possible
+ $ subuser install-from-registry --from-cache
+ """)
+
+
+def installFromRegistry(useCache):
+ """ Installs all of the programs listed in installed-programs.json file. """
+ installedPrograms = subuserlib.registry.getInstalledPrograms()
+ for program in installedPrograms.keys():
+  print("\n=== Installing <%s> from installed-programs.json registry....\n" % program)
+  if useCache:
+   subuserlib.utils.subprocessCheckedCall(["subuser","install",program,"--from-cache"])
+  else:
+   subuserlib.utils.subprocessCheckedCall(["subuser","install",program])
+
+#################################################################################################
+if len(sys.argv) > 1:
+ if sys.argv[1] == "help" or sys.argv[1] == "-h" or sys.argv[1] == "--help":
+  printHelp()
+  sys.exit()
+#################################################################################################
+
+# Are we to use layers from the cache when building the docker image: only for Dockerfiles build images
+useCache = False
+if len(sys.argv) > 1: 
+ if sys.argv[1] == "--from-cache":
+  useCache = True
+ else:
+  print("Wrong command: see\n")
+  printHelp()
+  sys.exit()
+  
+installFromRegistry(useCache) 


### PR DESCRIPTION
- Implemented install-from-registry command which installs all of the programs listed in installed-programs.json file. #23

first part of #61

BTW: if the `installed-programs.json`   is not perfect: e.g.  {"firefox": "2014-02-12-12:59"} which misses it's dependency it will still install firefox and build the required dependency

this might be nice if one wants to simple install a list of programs but does not want to define all dependencies one could do

JUST DID THE TEST
- $ sudo service docker stop
- $ sudo rm -rf /var/lib/docker
- $ sudo service docker start
- create: installed-programs.json

```
{
"firefox": "",  
"vim": ""
}
```
- $ subuser install-from-registry --from-cache

```
workerm@notebook:~$ subuser install-from-registry --from-cache

=== Installing <firefox> from installed-programs.json registry....

Installing libx11
Uploading context  2.56 kB
Uploading context 
Step 0 : FROM ubuntu

```

<b>all should be installed :+1: </b>

Final `installed-programs.json` will be overwritten and corrected

```
{"libx11": "2014-02-12-12:59", "firefox": "2014-02-12-12:59", "vim": "2014-02-12-12:59"}
```

```
workerm@notebook:~$ subuser list installed
libx11
firefox
vim
workerm@notebook:~$ 
```
