### PR TITLE
FIX: code typo

### DIFF
--- a/logic/subuserCommands/install-from-registry
+++ b/logic/subuserCommands/install-from-registry
@@ -21,8 +21,8 @@ def resetRegistry():
  """ Go through registry and unregister any program that is not actually installed. """
  registeredPrograms = subuserlib.registry.getInstalledPrograms()
  for program in registeredPrograms.keys():
-  if not subuser.dockerImages.isProgramsImageInstalled(program):
-   subuser.registry.unregisterProgram(program)
+  if not subuserlib.dockerImages.isProgramsImageInstalled(program):
+   subuserlib.registry.unregisterProgram(program)
 
 def installFromRegistry(useCache):
  """ Installs all of the programs listed in installed-programs.json file. """


### PR DESCRIPTION
```
workerm@notebook:~$ subuser install-from-registry
Traceback (most recent call last):
  File "/home/workerm/subuser/logic/subuserCommands/install-from-registry", line 55, in <module>
    installFromRegistry(useCache) 
  File "/home/workerm/subuser/logic/subuserCommands/install-from-registry", line 30, in installFromRegistry
    resetRegistry()
  File "/home/workerm/subuser/logic/subuserCommands/install-from-registry", line 24, in resetRegistry
    if not subuser.dockerImages.isProgramsImageInstalled(program):
NameError: global name 'subuser' is not defined
workerm@notebook:~$ 

```
