### PR TITLE
* Added: new command 'print-dependency-matrix' 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 VERSION 0.2
 -------------
 
+* Added: new command 'print-dependency-matrix' Which can take similar to 'list' the arguments: available, installed or a list of subuser-programs
+
 * Improved Python Files I/O code
 
 * Simplify some code dict.iteritems to dict.keys where applicable

--- a/logic/subuserCommands/print-dependency-matrix
+++ b/logic/subuserCommands/print-dependency-matrix
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+# This file should be compatible with both Python 2 and 3.
+# If it is not, please file a bug report.
+import sys
+import subuserlib.registry
+import subuserlib.availablePrograms
+
+def printHelp():
+ print("""print an extended dependency matrix: 
+ OPTION: names:  program-names (also multiple): print a dependency-matrix for program names
+  $ subuser print-dependency-matrix firefox vim xterm
+ 
+ Option: available: print a dependency-matrix for programs available
+  $ subuser print-dependency-matrix available
+ 
+ Option: installed: print a dependency-matrix for programs available
+  $ subuser print-dependency-matrix installed
+""")
+
+#################################################################################################
+if len(sys.argv) == 1 or sys.argv[1] == "help" or sys.argv[1] == "-h" or sys.argv[1] == "--help":
+ printHelp()
+ sys.exit()
+#################################################################################################
+
+if sys.argv[1] == "available":
+ subuserProgramList = subuserlib.availablePrograms.getAvailablePrograms()
+elif sys.argv[1] == "installed":
+ subuserProgramList = subuserlib.registry.getInstalledPrograms().keys()
+else:
+ subuserProgramList = sys.argv[1:]
+
+dependencyMatrix = subuserlib.registry.getDependencyMatrix(subuserProgramList, useHasExecutable=False, sortLists=True)
+print("\n===== DEPENDENCY MATRIX =====\n")
+for programMain in dependencyMatrix.keys():
+ print("<%s>:" % programMain)
+ print("    required-by: %s" % dependencyMatrix[programMain]["required-by"])
+ print("    depends-on: %s" % dependencyMatrix[programMain]["depends-on"])
+
+ 
+ 
+ 
+ 


### PR DESCRIPTION
Which can take similar to 'list' the arguments: available, installed or a list of subuser-programs

e.g. Multi name input

```
workerm@notebook:~$ subuser print-dependency-matrix firefox vim

===== DEPENDENCY MATRIX =====

<firefox>:
    required-by: []
    depends-on: ['firefox', u'libx11']
<vim>:
    required-by: []
    depends-on: ['vim']
workerm@notebook:~$ 

```

e.g. option:installed

```
subuser print-dependency-matrix installed

===== DEPENDENCY MATRIX =====

<libx11>:
    required-by: [u'firefox']
    depends-on: [u'libx11']
<firefox>:
    required-by: []
    depends-on: [u'firefox', u'libx11']
<vim>:
    required-by: []
    depends-on: [u'vim']
workerm@notebook:~$ 
```

e.g. Option: available

```
subuser print-dependency-matrix available

===== DEPENDENCY MATRIX =====

<firefox-java>:
    required-by: []
    depends-on: [u'firefox', 'firefox-java', u'libx11']
<libx11>:
    required-by: ['emacs', 'firefox', 'firefox-flash', 'firefox-java', 'libreoffice', 'skype', 'xterm']
    depends-on: ['libx11']
<firefox>:
    required-by: ['firefox-flash', 'firefox-java']
    depends-on: ['firefox', u'libx11']
<firefox-flash>:
    required-by: []
    depends-on: [u'firefox', 'firefox-flash', u'libx11']
<xterm>:
    required-by: []
    depends-on: [u'libx11', 'xterm']
<irssi>:
    required-by: []
    depends-on: ['irssi']
<vim>:
    required-by: []
    depends-on: ['vim']
<git>:
    required-by: []
    depends-on: ['git']
<emacs>:
    required-by: []
    depends-on: ['emacs', u'libx11']
<skype>:
    required-by: []
    depends-on: [u'libx11', 'skype']
<libreoffice>:
    required-by: []
    depends-on: ['libreoffice', u'libx11']
workerm@notebook:~$ 
```

The main function: getDependencyMatrix has some extras like: sorting useHasExecutable

e.g. with useHasExecutable: (this is not implemented in the command 'print-dependency-matrix')

```
===== DEPENDENCY MATRIX =====

<firefox-java>:
    required-by: []
    depends-on: [u'firefox', 'firefox-java', u'libx11']
    has-executable: True
<libx11>:
    required-by: ['emacs', 'firefox', 'firefox-flash', 'firefox-java', 'libreoffice', 'skype', 'xterm']
    depends-on: ['libx11']
    has-executable: False
<firefox>:
    required-by: ['firefox-flash', 'firefox-java']
    depends-on: ['firefox', u'libx11']
    has-executable: True
<firefox-flash>:
    required-by: []
    depends-on: [u'firefox', 'firefox-flash', u'libx11']
    has-executable: True
<xterm>:
    required-by: []
    depends-on: [u'libx11', 'xterm']
    has-executable: True
<irssi>:
    required-by: []
    depends-on: ['irssi']
    has-executable: True
<vim>:
    required-by: []
    depends-on: ['vim']
    has-executable: True
<git>:
    required-by: []
    depends-on: ['git']
    has-executable: True
<emacs>:
    required-by: []
    depends-on: ['emacs', u'libx11']
    has-executable: True
<skype>:
    required-by: []
    depends-on: [u'libx11', 'skype']
    has-executable: True
<libreoffice>:
    required-by: []
    depends-on: ['libreoffice', u'libx11']
    has-executable: True
workerm@notebook:~$ 
```

Also if one has by mistake defined a wrong dependency in the permission.json it raises an error -quite useful I think best used `subuser print-dependency-matrix available`  I manually introduced an error and the output is

```
subuser print-dependency-matrix available
ERROR:  [Errno 2] No such file or directory: u'/home/workerm/subuser/programsThatCanBeInstalled/firefox-not-here/permissions.json' 

  Suggestion: maybe it is defined as a wrong dependency in a permission.json file

workerm@notebook:~$ 

```

I know this could be more specific buy it is only a side effect and not a feature (at the moment)
