### PR TITLE
* FIX: The mark-as-needing-update command messes up the order of attribu...

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 VERSION 0.2
 -------------
 
+* FIX: The mark-as-needing-update command messes up the order of attributes in permissions.json #32
+
 * Implemented new installed-programs.json format: issue #63
 
 * Refactored/Added getRegistry and getInstalledPrograms to a list like: getAvailablePrograms and added #75

--- a/logic/subuserCommands/subuserlib/permissions.py
+++ b/logic/subuserCommands/subuserlib/permissions.py
@@ -5,6 +5,7 @@ import paths
 import json
 import os
 import sys
+import collections
 
 def getPermissions(programName):
  """ Return the permissions for the given program. """
@@ -13,7 +14,7 @@ def getPermissions(programName):
  if not os.path.exists(permissionsFilePath):
   sys.exit("The permissions.json file for the program "+programName+" does not exist.  All subuser programs must have a permissions.json file as defined by the permissions.json standard: <https://github.com/subuser-security/subuser/blob/master/docs/permissions-dot-json-file-format.md>")
  with open(permissionsFilePath, 'r') as file_f:
-  permissions=json.load(file_f)
+  permissions=json.load(file_f, object_pairs_hook=collections.OrderedDict)
   return permissions
 
 def setPermissions(programName,permissions):


### PR DESCRIPTION
- FIX: The mark-as-needing-update command messes up the order of attributes in permissions.json #32

should do the trick: but does slightly reformat the output to json indention ect:

depends how one writes the permission file: e.g. comma in the beginning :)
