### PR TITLE
improved commandline option: multi progam names

### DIFF
--- a/logic/subuserCommands/print-dependency-tree
+++ b/logic/subuserCommands/print-dependency-tree
@@ -5,8 +5,8 @@ import sys
 import subuserlib.registry
 
 def printHelp():
-  print("""Print the dependency tree of a subuser program:
-  $ subuser dependency-tree program-name
+  print("""Print the dependency tree of a subuser programs (also multiple):
+  $ subuser dependency-tree firefox vim xterm
 """)
 
 #################################################################################################
@@ -15,13 +15,15 @@ if len(sys.argv) == 1 or sys.argv[1] == "help" or sys.argv[1] == "-h" or sys.arg
   sys.exit()
 #################################################################################################
 
-programName = sys.argv[1]
 
-treeString = ''
-for index, dependency in enumerate(subuserlib.registry.getDependencyTree(programName)):
-  if index > 0:
-    treeString = ''.join([treeString, '  ' * index, '|__', dependency, '\n'])
-  else:
-    treeString = ''.join([treeString, dependency, '\n'])
+programList = sys.argv[1:]
+print("\n===== DEPENDENCY TREE =====\n")
+for programMain in programList:
+  treeString = ''
+  for index, dependency in enumerate(subuserlib.registry.getDependencyTree(programMain)):
+    if index > 0:
+      treeString = ''.join([treeString, '  ' * index, '|__', dependency, '\n'])
+    else:
+      treeString = ''.join([treeString, dependency, '\n'])
 
-print treeString
+  print treeString


### PR DESCRIPTION
allow multiple program names
https://github.com/subuser-security/subuser/issues/8

```
workerm@notebook:~$ subuser print-dependency-tree firefox vim xterm

===== DEPENDENCY TREE =====

firefox
  |__libx11

vim

xterm
  |__libx11

workerm@notebook:~$ 
```
