### PR TITLE
FIX hopefully the problem with spaces in tags

### DIFF
--- a/logic/subuserCommands/subuserlib/dockerImages.py
+++ b/logic/subuserCommands/subuserlib/dockerImages.py
@@ -142,3 +142,29 @@ def getUniqueRowByRepTag(dockerImageMatrix, searchRepoName, searchTag='latest'):
       break
   return dockerImageMatrixRow
   
+def getSubuserDockerRepoNameTagsText(addNewLine=False, indentSpaces=0):
+  """ Returns a string representing a sorted list of subuser-program names which are actual docker images
+  Arguments:
+   - indentSpaces: can be set for nicer output especially togehter with: addNewLine
+   - addNewLine: if True each installed program's name starts at a new line
+  
+  e.g.: `print(getInstalledProgramsText(addNewLine=True, indentSpaces=3))`
+  """
+  outText = ''
+  indentionString = ''
+  if indentSpaces > 0:
+    indentionString = ' ' * indentSpaces
+    
+  dockerSubuserProgramsRepoTagList = []
+  dockerImageMatrix = getParsedDockerImages(noTrunc=True)
+  for index, name in enumerate(dockerImageMatrix['REPOSITORY']):
+    if name.startswith('subuser-'):
+      dockerSubuserProgramsRepoTagList.append('%s:%s' % (dockerImageMatrix['REPOSITORY'][index], dockerImageMatrix['TAG'][index]))
+    
+  if addNewLine:
+    for program in sorted(dockerSubuserProgramsRepoTagList):
+      outText = ''.join([outText, indentionString, program, '\n'])
+  else:
+    outText = indentionString + ' '.join(sorted(dockerSubuserProgramsRepoTagList))
+  return outText
+  


### PR DESCRIPTION
https://github.com/subuser-security/subuser/issues/99

I put a bit more of example usage in it: if you do not like just erase them: some examples

```
workerm@notebook:~$ subuser save-compressed-images docker
('getAllRepoNameWhichStartWith: ', ['subuser-firefox', 'subuser-firefox', 'subuser-libx11', 'subuser-vim'])


getUniqueRowByRepTag 'subuser-firefox', 'latest' : <{'SIZE': '402.1 MB', 'TAG': 'latest', 'ID': '197837e70eb5cc29dae51cfcc191263bbdbbaa8fd0b7a2088d7e2d1461944610', 'REPOSITORY': 'subuser-firefox', 'CREATED': '33 hours ago'}>

("Search for tags with spaces: 'zz  233  e', 'dgfz 45' ", {'SIZE': '204.4 MB', 'TAG': 'dgfz 45', 'ID': '9cd978db300e27386baa9dd791bf6dc818f13e52235b26e95703361ec3c94dc6', 'REPOSITORY': 'zz  233  e', 'CREATED': '2 weeks ago'})

SIZE: <402.1 MB>

FOUND: 'subuser-firefox', 'latest'

('getImageTagOfProgram: ', 'subuser-firefox')
workerm@notebook:~$ 

```
