### PR TITLE
Addition/improvements to utils.py

### DIFF
--- a/logic/subuserCommands/subuserlib/utils.py
+++ b/logic/subuserCommands/subuserlib/utils.py
@@ -3,11 +3,61 @@
 # If it is not, please file a bug report.
 import sys
 import subprocess
+import availablePrograms
 
-def subprocessCheckedCall(args, **kwargs):
+def subprocessCheckedCall(args, addToErrorInfo=''):
   """ simplify subprocess.check_call in other code
+  e.g.
+  subprocessCheckedCall(["docker", "-d"], "ATTENTION: Special added info bla bla")
   """
   try:
-    subprocess.check_call(args, **kwargs)
-  except subprocess.CalledProcessError:
-    sys.exit('Command failed: %s' % ' '.join(args))
+    subprocess.check_call(args)
+  except Exception as err:
+    if addToErrorInfo:
+      message = ('''Command <{0}> failed:\n  ERROR: {1}\n    {2}'''.format(' '.join(args), err, addToErrorInfo))
+    else:
+      message = ('''Command <{0}> failed:\n  ERROR: {1}'''.format(' '.join(args), err))
+    sys.exit(message)
+    
+def subprocessCheckedOutput(args, addToErrorInfo=''):
+  """ simplify subprocess.check_output in other code
+  returns output or raises error
+  subprocessCheckedOutput(["docker", "-d"], "ATTENTION: Special added info bla bla")
+  """
+  try:
+    return subprocess.check_output(args)
+  except Exception as err:
+    if addToErrorInfo:
+      message = ('''Command <{0}> failed:\n  ERROR: {1}\n    {2}'''.format(' '.join(args), err, addToErrorInfo))
+    else:
+      message = ('''Command <{0}> failed:\n  ERROR: {1}'''.format(' '.join(args), err))
+    sys.exit(message)
+    
+def getUserCommandLine(argvList, commandOptionList):
+  """ ASSUMPTION: any commandline argument which is not a define option is a program name
+  To make it more useful: precheck if all program names are 'really' subuser available programs
+  
+  returns tuple (preCheckProgramNameList, userOptionList)
+  e.g:
+  userProgramList = getUserCommandLine(sys.argv[1:], [])[0]
+  
+  commandOptionList = ['--from-cache']
+  userProgramList, userOptionList = getUserCommandLine(sys.argv[1:], commandOptionList)
+  """
+  preCheckProgramNameList = []
+  userOptionList = []
+  
+  for item in argvList:
+    if item in commandOptionList:
+      userOptionList.append(item)
+    else:
+      preCheckProgramNameList.append(item)
+
+  for programName in preCheckProgramNameList:
+    if not availablePrograms.available(programName):
+      print("<{0}> not an available subuser-program".format(programName))
+      print("\nAvailable programs are:")
+      print(availablePrograms.getAvailableProgramsText(addNewLine=True, indentSpaces=3))
+      sys.exit()
+  
+  return (preCheckProgramNameList, userOptionList)


### PR DESCRIPTION
https://github.com/subuser-security/subuser/issues/61

improved subprocessCheckedCall: argument: addToErrorInfo
e.g.code

```
subuserlib.utils.subprocessCheckedCall(["docker", "-d"], "ATTENTION: Special added info bla bla")
```

output

```
[/var/lib/docker|1038baec] +job initserver()
[/var/lib/docker|1038baec.initserver()] Creating server
mkdir /var/lib/docker/containers: permission denied[/var/lib/docker|1038baec] -job initserver() = ERR (1)
2014/02/21 09:53:09 initserver: mkdir /var/lib/docker/containers: permission denied
Command <docker -d> failed:
  ERROR: Command '['docker', '-d']' returned non-zero exit status 1
    ATTENTION: Special added info bla bla
workerm@notebook:~$ 


```

https://github.com/subuser-security/subuser/issues/8
ADDED: utils.getUserCommandLine

this will help to solve some of #8

used code for install

```
commandOptionList = ['--from-cache']
userProgramList, userOptionList = subuserlib.utils.getUserCommandLine(sys.argv[1:], commandOptionList)
print('userProgramList: ', userProgramList)
print('userOptionList: ', userOptionList)
```

outputs: multiple programs called with option

```
workerm@notebook:~$ subuser install vim firefox --from-cache
('userProgramList: ', ['vim', 'firefox'])
('userOptionList: ', ['--from-cache'])
workerm@notebook:~$ 

```

option are not confined anymore to any specific order in the commandline arguments

```
workerm@notebook:~$ subuser install --from-cache vim firefox
('userProgramList: ', ['vim', 'firefox'])
('userOptionList: ', ['--from-cache'])
workerm@notebook:~$ 
```

wrong program

```
subuser install libx11 --from-cache vim firefox  wrongprogram
<wrongprogram> not an available subuser-program

Available programs are:
   docker-in-docker
   elm-get-git-dev
   elm-git-dev
   emacs
   firefox
   firefox-flash
   firefox-java
   firefox_libx11_libubuntu_precise
   git
   irssi
   libelm-platform-git-dev
   libhaskell-platform
   libreoffice
   libubuntu_precise
   libx11
   libx11_libubuntu_precise
   skype
   vim
   xterm

workerm@notebook:~$ 
```
