### PR TITLE
improvement: getUserCommandLine

### DIFF
--- a/logic/subuserCommands/subuserlib/utils.py
+++ b/logic/subuserCommands/subuserlib/utils.py
@@ -3,11 +3,96 @@
 # If it is not, please file a bug report.
 import sys
 import subprocess
+import availablePrograms
 
-def subprocessCheckedCall(args, **kwargs):
+def subprocessCheckedCall(args, addToErrorInfo=''):
   """ simplify subprocess.check_call in other code
+  e.g.
+  subprocessCheckedCall(["docker", "-d"], "ATTENTION: Special added info bla bla")
   """
   try:
-    subprocess.check_call(args, **kwargs)
-  except subprocess.CalledProcessError:
-    sys.exit('Command failed: %s' % ' '.join(args))
+    subprocess.check_call(args)
+  except Exception as err:
+    if addToErrorInfo:
+      message = ('''Command <{0}> failed:\n  ERROR: {1}\n    {2}'''.format(' '.join(args), err, addToErrorInfo))
+    else:
+      message = ('''Command <{0}> failed:\n  ERROR: {1}'''.format(' '.join(args), err))
+    sys.exit(message)
+    
+def subprocessCheckedOutput(args, addToErrorInfo=''):
+  """ simplify subprocess.check_output in other code
+  returns output or raises error
+  subprocessCheckedOutput(["docker", "-d"], "ATTENTION: Special added info bla bla")
+  """
+  try:
+    return subprocess.check_output(args)
+  except Exception as err:
+    if addToErrorInfo:
+      message = ('''Command <{0}> failed:\n  ERROR: {1}\n    {2}'''.format(' '.join(args), err, addToErrorInfo))
+    else:
+      message = ('''Command <{0}> failed:\n  ERROR: {1}'''.format(' '.join(args), err))
+    sys.exit(message)
+    
+def getUserCommandLine(argvList, commandOptionList, allowOnlyOptions=False):
+  """ ASSUMPTION: any commandline argument which is not a define option is a program name
+  To make it more useful: precheck if all program names are 'really' subuser available programs
+  
+  returns tuple (preCheckProgramNameList, userOptionList)
+  e.g:
+  userProgramList = getUserCommandLine(sys.argv[1:], [])[0]
+  
+  commandOptionList = ['--from-cache']
+  userProgramList, userOptionList = getUserCommandLine(sys.argv[1:], commandOptionList)
+  
+  if allowOnlyOptions=True an error is raised if a programName is supplied
+  This is useful for commands like: subuser list
+  """
+  preCheckProgramNameList = []
+  userOptionList = []
+  
+  for item in argvList:
+    if item in commandOptionList:
+      userOptionList.append(item)
+    else:
+      preCheckProgramNameList.append(item)
+      
+  #check: allowOnlyOptions
+  if allowOnlyOptions:
+    if preCheckProgramNameList:
+      print("INPUT-ERROR. Supplied command arguments: <{0}> ".format(' '.join(argvList)))
+      print("\nOnly Command Options are allowed: <{0}> ".format(' '.join(commandOptionList)))
+      print("\nFor mor info see the help: `subuser -h`")
+      sys.exit()
+
+  for programName in preCheckProgramNameList:
+    if not availablePrograms.available(programName):
+      print("<{0}> not an available subuser-program".format(programName))
+      print("\nAvailable programs are:")
+      print(availablePrograms.getAvailableProgramsText(addNewLine=True, indentSpaces=3))
+      sys.exit()
+  
+  return (preCheckProgramNameList, userOptionList)
+
+
+def getExclusiveCommandOptionText(exclusiveCommandOptionList, addNewLine=False, indentSpaces=0):
+  """ Returns a string representing a sorted list of exclusive commandline options.
+  Arguments:
+   - exclusiveCommandOptionList: e.g. 
+   - indentSpaces: can be set for nicer output especially togehter with: addNewLine
+   - addNewLine: if True each installed program's name starts at a new line
+  
+  e.g.: `
+  exclusiveCommandOptionList = ["--available", "--installed"]
+  print(getExclusiveCommandOptionText(exclusiveCommandOptionList, addNewLine=True, indentSpaces=3))
+  """
+  outText = ''
+  indentionString = ''
+  if indentSpaces > 0:
+    indentionString = ' ' * indentSpaces
+    
+  if addNewLine:
+    for program in sorted(exclusiveCommandOptionList):
+      outText = ''.join([outText, indentionString, program, '\n'])
+  else:
+    outText = indentionString + ' '.join(sorted(exclusiveCommandOptionList))
+  return outText


### PR DESCRIPTION
added to previous pullrequest an enhancement: getUserCommandLine(argvList, commandOptionList, allowOnlyOptions=False):
e.g. in `subuser list` does only allow option to be set but not any specific program names

e.g. code: from the `list` command I adjust

```
commandOptionList = ['--available', '--installed', '--short']
userProgramList, userOptionList = subuserlib.utils.getUserCommandLine(sys.argv[1:], commandOptionList, allowOnlyOptions=True)

```

user calls it like `subuser list firefox --installed`

```
workerm@notebook:~$ subuser list firefox --installed
INPUT-ERROR. command input was: <firefox --installed> 

Only Command Options are allowed: <--available --installed --short> 

For mor info see the help: `subuser -h`
workerm@notebook:~$ 


```
