### PR TITLE
ENHANCEMENT:  command list using new functions

### DIFF
--- a/logic/subuserCommands/list
+++ b/logic/subuserCommands/list
@@ -10,14 +10,20 @@ import subuserlib.permissions
 import subuserlib.availablePrograms
 
 def printHelp():
-  print("""You can either list programs available for instalation with:
-  $ subuser list available
+  print("""List subuser-programs:
+  $ subuser list [options]
+  
+  OPTIONS:
+  --available 
+      List all subuser-programs
+  --installed 
+      List all subuser-programs which are already installed/registered
+  --short 
+      output only program names
 
-    The list available command may optionally take the `--short` argument which will print only the program's names.
-    $ subuser list available --short
-
-Or you can list installed programs with:
-  $ subuser list installed
+  EXAMPLES:
+    $ subuser list --available --short
+    $ subuser list --installed
 """)
 
 #################################################################################################
@@ -26,15 +32,26 @@ if len(sys.argv) == 1 or sys.argv[1] == "help" or sys.argv[1] == "-h" or sys.arg
   sys.exit()
 #################################################################################################
 
-if sys.argv[1] == "available":
-  try:
-    if sys.argv[2] == "--short":
-      availableProgramsPath = subuserlib.paths.getAvailableProgramsPath()
-      print(' '.join(sorted([program for program in os.listdir(availableProgramsPath)])))
-    else:
-      print("Argument not recognized:"+sys.argv[2])
-      printHelp()
-  except IndexError:
+commandOptionList = ['--available', '--installed', '--short']
+userProgramList, userOptionList = subuserlib.utils.getUserCommandLine(sys.argv[1:], commandOptionList, allowOnlyOptions=True)
+
+#ERROR if user specifies any programs
+if userProgramList:
+  printHelp()
+  sys.exit()
+  
+#Check exclusive commands
+if '--available' in userOptionList and '--installed' in userOptionList:
+  print("\nEXCLUSIVE-OPTION-ERROR: you can not use these options together:")
+  exclusiveCommandOption = ["--available", "--installed"]
+  print(subuserlib.utils.getExclusiveCommandOptionText(exclusiveCommandOption, addNewLine=True, indentSpaces=3))
+  sys.exit()
+
+
+if '--available' in userOptionList:
+  if '--short' in userOptionList:
+    print(subuserlib.availablePrograms.getAvailableProgramsText(addNewLine=False, indentSpaces=3))
+  else:
     availablePrograms = subuserlib.availablePrograms.getAvailablePrograms()
     for program in availablePrograms:
       permissions = subuserlib.permissions.getPermissions(program)
@@ -43,10 +60,17 @@ if sys.argv[1] == "available":
       print("Description: "+permissions["description"])
       print("Maintainer: "+permissions["maintainer"])
       print("\n")
-
-elif sys.argv[1] == "installed":
-  for program in subuserlib.registry.getInstalledPrograms():
-    print(program)
-
-else:
-  printHelp()
+elif '--installed' in userOptionList:
+  #use this in case the user specified also some program names plus --installed
+  userProgramList = list(set(userProgramList + subuserlib.registry.getInstalledPrograms())) 
+  if '--short' in userOptionList:
+    print(subuserlib.registry.getInstalledProgramsText(addNewLine=False, indentSpaces=3))
+  else:
+    installedePrograms = subuserlib.registry.getInstalledPrograms()
+    for program in installedePrograms:
+      permissions = subuserlib.permissions.getPermissions(program)
+      print(program)
+      print("----------------")
+      print("Description: "+permissions["description"])
+      print("Maintainer: "+permissions["maintainer"])
+      print("\n")


### PR DESCRIPTION
#61 #8
- unified options see #112
- using the new functions
  - utils.getUserCommandLine
  - utils.getExclusiveCommandOptionText
- unify option: `--short` can now be used for available and installed
- some error checks

e.g.

```
workerm@notebook:~$ subuser list --availa --short
INPUT-ERROR. Supplied command arguments: <--availa --short> 

Only Command Options are allowed: <--available --installed --short> 

For mor info see the help: `subuser -h`


workerm@notebook:~$ subuser list --available --short
   docker-in-docker elm-get-git-dev elm-git-dev emacs firefox firefox-flash firefox-java git irssi libelm-platform-git-dev libhaskell-platform libreoffice libx11 skype vim xterm
workerm@notebook:~$ 


workerm@notebook:~$ subuser list --installed --short
   libx11 vim xterm
workerm@notebook:~$


workerm@notebook:~$ subuser list --installed
vim
----------------
Description: A simple powerful text editor
Maintainer: Timothy Hobbs <timothyhobbs (at) seznam dot cz>


xterm
----------------
Description: A trivial terminal emulator
Maintainer: Timothy Hobbs <timothyhobbs (at) seznam dot cz>


libx11
----------------
Description: A basic image with X11 packages
Maintainer: Timothy Hobbs <timothyhobbs (at) seznam dot cz>


workerm@notebook:~$ 


```
