### PR TITLE
Replace 'firefox' with 'iceweasel'

### DIFF
--- a/docs/flaws.rst
+++ b/docs/flaws.rst
@@ -1,7 +1,7 @@
 Design flaws/bugs in subuser
 ============================
 
-* Application startup time is slowed.  On my system with Docker's ``aufs`` backend it takes 2.5 seconds extra time for all applications, be it ``vim`` or ``firefox``.  I have read reports that on newer systems with SSDs and ``btrfs`` this can be reduced to a quarter of a second.
+* Application startup time is slowed.  On my system with Docker's ``aufs`` backend it takes 2.5 seconds extra time for all applications, be it ``vim`` or ``iceweasel``.  I have read reports that on newer systems with SSDs and ``btrfs`` this can be reduced to a quarter of a second.
 
 * Certain things involving sharing of data between applications, like the clipboard in `vim`, just won't work.
 

--- a/docs/packaging.rst
+++ b/docs/packaging.rst
@@ -68,12 +68,12 @@ Example::
 Example2::
 
   FROM-SUBUSER-IMAGE libx11
-  RUN apt-get update && apt-get install -yyq firefox
+  RUN apt-get update && apt-get install -yyq iceweasel
 
 Example3::
 
   FROM debian
-  RUN apt-get update && apt-get install -yyq firefox
+  RUN apt-get update && apt-get install -yyq iceweasel
 
 .. note :: Examples 2 and 3 do the **SAME** thing, it's just that Example3 takes a little longer to build and uses more space on disk.  There is **no magic** in the ``libx11`` image and never will be(we hope).
 

--- a/logic/subuserCommands/describe.py
+++ b/logic/subuserCommands/describe.py
@@ -14,10 +14,10 @@ def parseCliArgs(sysargs):
 
 EXAMPLE:
 
-    $ subuser describe image firefox
+    $ subuser describe image iceweasel
     <lots of info>
 
-    $ subuser describe subuser firefox
+    $ subuser describe subuser iceweasel
 """
   parser = optparse.OptionParser(usage=usage,description=description,formatter=subuserlib.commandLineArguments.HelpFormatterThatDoesntReformatDescription())
   return parser.parse_args(args=sysargs)

--- a/logic/subuserCommands/dry-run.py
+++ b/logic/subuserCommands/dry-run.py
@@ -14,9 +14,9 @@ Display the command which would be issued to launch Docker if you were to run th
 
 For example:
 
-    $ subuser dry-run firefox
+    $ subuser dry-run iceweasel
 
-Will display the command used to launch the subuser firefox.
+Will display the command used to launch the subuser iceweasel.
 
 Please note, this is only a rough approximation for debugging purposes and there is no guarantee that the command displayed here would actually work.
 """

--- a/logic/subuserCommands/mark-as-updated.py
+++ b/logic/subuserCommands/mark-as-updated.py
@@ -15,7 +15,7 @@ Mark a image as needing to be updated.  Note, that this may mess up the formatti
 
 EXAMPLE:
 
-    $ subuser mark-as-updated firefox/permissions.json 
+    $ subuser mark-as-updated iceweasel/permissions.json 
 """
   parser=optparse.OptionParser(usage=usage,description=description,formatter=subuserlib.commandLineArguments.HelpFormatterThatDoesntReformatDescription())
   return parser.parse_args(args=sysargs)

--- a/logic/subuserCommands/run.py
+++ b/logic/subuserCommands/run.py
@@ -13,9 +13,9 @@ helpString = """Run the given subuser.
 
 For example:
 
-    $ subuser run firefox
+    $ subuser run iceweasel
 
-Will launch the subuser named firefox.
+Will launch the subuser named iceweasel
 """
 
 #################################################################################################


### PR DESCRIPTION
The sub 'firefox' is not available in the default repository. The
sub 'iceweasel' should be used.
