### PR TITLE
Update installation.rst

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -23,7 +23,7 @@ Instalation
   $ cd
   $ git clone https://github.com/subuser-security/subuser
 
-3. Add ``subuser/logic`` and ``~/.subuser/bin`` to your path by adding the line ``PATH=$PATH:$HOME/subuser/logic:$HOME/.subuser/bin`` to the end of your ``.bashrc`` file.
+3. Add ``subuser/logic`` and ``~/.subuser/bin`` to your path by adding the line ``PATH=$HOME/subuser/logic:$HOME/.subuser/bin:$PATH`` to the end of your ``.bashrc`` file.
 
 .. note:: You will need to change the path to ``subuser/logic`` to refer to the location to which you downloaded subuser.
 


### PR DESCRIPTION
I did a fresh debain 8 installation with iceweasel and later installed subuser's iceweasel.

the shortcut was not found

```
$ which iceweasel
/usr/bin/iceweasel
```

I guess the PATH should first specify the subuser.

P