### PR TITLE
runtime: handle if /dev/dsp is not a directory

### DIFF
--- a/logic/subuserlib/classes/subuserSubmodules/run/runtime.py
+++ b/logic/subuserlib/classes/subuserSubmodules/run/runtime.py
@@ -88,7 +88,10 @@ $ subuser repair
       soundArgs += ["--device=/dev/snd/"+device for device in os.listdir("/dev/snd") if not device == "by-id" and not device == "by-path"]
     if os.path.exists("/dev/dsp"):
       soundArgs += ["--volume=/dev/dsp:/dev/dsp"]
-      soundArgs += ["--device=/dev/dsp/"+device for device in os.listdir("/dev/dsp")]
+      if os.path.isdir('/dev/dsp'):
+        soundArgs += ["--device=/dev/dsp/"+device for device in os.listdir("/dev/dsp")]
+      else:
+        soundArgs += ["--device=/dev/dsp"]
     return soundArgs
 
   def getPermissionFlagDict(self):


### PR DESCRIPTION
In case /dev/dsp is an device file, the previous implementation dies.
It happens when ALSA's OSS emulation is not complete.

Check if /dev/dsp is a directory, if it isn't, don't try to traverse it.