### PR TITLE
Wait for Xpra server to write 'xpra is ready' to stderr before continuing

### DIFF
--- a/logic/subuserlib/classes/docker/dockerDaemon.py
+++ b/logic/subuserlib/classes/docker/dockerDaemon.py
@@ -223,14 +223,14 @@ class DockerDaemon(UserOwnedObject):
     else:
       return json.loads(response.read().decode("utf-8"))
 
-  def execute(self,args,cwd=None,background=False,backgroundSuppressOutput=True):
+  def execute(self,args,cwd=None,background=False,backgroundSuppressOutput=True,backgroundCollectOutput=False):
     """
     Execute the docker client.
-    If the background argument is True, return emediately with the docker client's pid.
+    If the background argument is True, return emediately with the docker client's subprocess.
     Otherwise, wait for the process to finish and return the docker client's exit code.
     """
     if background:
-      return subuserlib.docker.runBackground(args,cwd=cwd,suppressOutput=backgroundSuppressOutput)
+      return subuserlib.docker.runBackground(args,cwd=cwd,suppressOutput=backgroundSuppressOutput,collectOutput=backgroundCollectOutput)
     else:
       return subuserlib.docker.run(args,cwd=cwd)
 

--- a/logic/subuserlib/docker.py
+++ b/logic/subuserlib/docker.py
@@ -53,8 +53,8 @@ def run(args,cwd=None):
   """
   return subprocessExtras.call([getAndVerifyExecutable()]+args,cwd)
 
-def runBackground(args,cwd=None,suppressOutput=True):
+def runBackground(args,cwd=None,suppressOutput=True,collectOutput=False):
   """
   Run docker with the given command line arguments. Return Docker's pid.
   """
-  return subprocessExtras.callBackground([getAndVerifyExecutable()]+args,cwd,suppressOutput=suppressOutput)
+  return subprocessExtras.callBackground([getAndVerifyExecutable()]+args,cwd,suppressOutput=suppressOutput,collectOutput=collectOutput)

--- a/logic/subuserlib/subprocessExtras.py
+++ b/logic/subuserlib/subprocessExtras.py
@@ -22,17 +22,19 @@ def call(args,cwd=None):
   (stdout,stderr) = process.communicate()
   return process.returncode
 
-def callBackground(args,cwd=None,suppressOutput=True):
+def callBackground(args,cwd=None,suppressOutput=True,collectOutput=False):
   """
   Same as subprocess.call except here you can specify the cwd.
-  Returns imediately with the subprocesses pid.
+  Returns imediately with the subprocess
   """
-  if suppressOutput:
+  if collectOutput:
+    process = subprocess.Popen(args,cwd=cwd,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
+  elif suppressOutput:
     devnull = open(os.devnull,"a")
     process = subprocess.Popen(args,cwd=cwd,stdout=devnull,stderr=devnull,close_fds=True)
   else:
     process = subprocess.Popen(args,cwd=cwd)
-  return process.pid
+  return process
 
 def callCollectOutput(args,cwd=None):
   """


### PR DESCRIPTION
Added a "collectOutput" parameter to the subprocessExtras.callBackground function, which pipes stdout/stderr. Using this functionality, the x11Bridge.py waitForServerContainerToLaunch method can now listen and wait until the Xpra server outputs 'xpra is ready' to stderr, before continuing normally.

After these changes, I am unable to reproduce issue #224, and everything else seems to work fine.

Note: I am new at this open-source contribution thing, so feel free to give advice if I did anything wrong :)