### PR TITLE
Use tempfiles instead of pipes, wait for Xpra client as well

### DIFF
--- a/logic/subuserlib/classes/docker/dockerDaemon.py
+++ b/logic/subuserlib/classes/docker/dockerDaemon.py
@@ -223,14 +223,14 @@ class DockerDaemon(UserOwnedObject):
     else:
       return json.loads(response.read().decode("utf-8"))
 
-  def execute(self,args,cwd=None,background=False,backgroundSuppressOutput=True,backgroundCollectOutput=False):
+  def execute(self,args,cwd=None,background=False,backgroundSuppressOutput=True,backgroundCollectStdout=False,backgroundCollectStderr=False):
     """
     Execute the docker client.
     If the background argument is True, return emediately with the docker client's subprocess.
     Otherwise, wait for the process to finish and return the docker client's exit code.
     """
     if background:
-      return subuserlib.docker.runBackground(args,cwd=cwd,suppressOutput=backgroundSuppressOutput,collectOutput=backgroundCollectOutput)
+      return subuserlib.docker.runBackground(args,cwd=cwd,suppressOutput=backgroundSuppressOutput,collectStdout=backgroundCollectStdout,collectStderr=backgroundCollectStderr)
     else:
       return subuserlib.docker.run(args,cwd=cwd)
 

--- a/logic/subuserlib/classes/subuserSubmodules/run/runtime.py
+++ b/logic/subuserlib/classes/subuserSubmodules/run/runtime.py
@@ -32,7 +32,8 @@ class Runtime(UserOwnedObject):
     self.__subuser = subuser
     self.__environment = environment
     self.__backgroundSuppressOutput = True
-    self.__backgroundCollectOutput = False
+    self.__backgroundCollectStdout = False
+    self.__backgroundCollectStderr = False
     self.__executionSpoolReader = None
     if extraDockerFlags is None:
       self.__extraFlags = []
@@ -200,13 +201,14 @@ $ subuser repair
     return self.__backgroundSuppressOutput
 
   def getBackgroundCollectOutput(self):
-    return self.__backgroundCollectOutput
+    return (self.__backgroundCollectStdout, self.__backgroundCollectStderr)
 
   def setBackgroundSuppressOutput(self,suppressOutput):
     self.__backgroundSuppressOutput = suppressOutput
 
-  def setBackgroundCollectOutput(self,collectOutput):
-    self.__backgroundCollectOutput = collectOutput
+  def setBackgroundCollectOutput(self,collectStdout,collectStderr):
+    self.__backgroundCollectStdout = collectStdout
+    self.__backgroundCollectStderr = collectStderr
 
   def getXautorityDirPath(self):
     return os.path.join(self.getUser().getConfig()["volumes-dir"],"x11",self.getSubuser().getName(),"subuser")
@@ -280,7 +282,8 @@ $ subuser repair
       if not self.getSubuser().getPermissions()["gui"] is None:
         self.getSubuser().getX11Bridge().addClient()
       command = self.getCommand(args)
-      returnValue = self.getUser().getDockerDaemon().execute(command,background=self.getBackground(),backgroundSuppressOutput=self.getBackgroundSuppressOutput(),backgroundCollectOutput=self.getBackgroundCollectOutput())
+      (collectStdout,collectStderr) = self.getBackgroundCollectOutput()
+      returnValue = self.getUser().getDockerDaemon().execute(command,background=self.getBackground(),backgroundSuppressOutput=self.getBackgroundSuppressOutput(),backgroundCollectStdout=collectStdout,backgroundCollectStderr=collectStderr)
       if self.getSubuser().getPermissions()["run-commands-on-host"]:
         self.tearDownExecutionSpool()
       if not self.getSubuser().getPermissions()["gui"] is None:

--- a/logic/subuserlib/classes/subuserSubmodules/run/x11Bridge.py
+++ b/logic/subuserlib/classes/subuserSubmodules/run/x11Bridge.py
@@ -194,10 +194,8 @@ class XpraX11Bridge(Service):
     clientRuntime.setEnvVar("XPRA_SOCKET_HOSTNAME","server")
     clientRuntime.setBackground(True)
     clientRuntime.setBackgroundSuppressOutput(suppressOutput)
-    clientRuntime.setBackgroundCollectOutput(False,True)
     (clientContainer, clientProcess) = clientRuntime.run(args=clientArgs)
     serviceStatus["xpra-client-service-cid"] = clientContainer.getId()
-    self.waitForContainerToLaunch("Attached to", clientProcess, suppressOutput)
     return serviceStatus
 
   def waitForContainerToLaunch(self, readyString, process, suppressOutput):
@@ -212,6 +210,7 @@ class XpraX11Bridge(Service):
           print line,
         if readyString in line:
           break
+    process.stderr_file.close()
 
   def stop(self,serviceStatus):
     """

--- a/logic/subuserlib/docker.py
+++ b/logic/subuserlib/docker.py
@@ -53,8 +53,8 @@ def run(args,cwd=None):
   """
   return subprocessExtras.call([getAndVerifyExecutable()]+args,cwd)
 
-def runBackground(args,cwd=None,suppressOutput=True,collectOutput=False):
+def runBackground(args,cwd=None,suppressOutput=True,collectStdout=False,collectStderr=False):
   """
   Run docker with the given command line arguments. Return Docker's pid.
   """
-  return subprocessExtras.callBackground([getAndVerifyExecutable()]+args,cwd,suppressOutput=suppressOutput,collectOutput=collectOutput)
+  return subprocessExtras.callBackground([getAndVerifyExecutable()]+args,cwd,suppressOutput=suppressOutput,collectStdout=collectStdout,collectStderr=collectStderr)

--- a/logic/subuserlib/subprocessExtras.py
+++ b/logic/subuserlib/subprocessExtras.py
@@ -9,6 +9,7 @@ Helper functions for running foreign executables.
 #external imports
 import subprocess
 import os
+import tempfile
 #internal imports
 #import ...
 
@@ -22,18 +23,33 @@ def call(args,cwd=None):
   (stdout,stderr) = process.communicate()
   return process.returncode
 
-def callBackground(args,cwd=None,suppressOutput=True,collectOutput=False):
+def callBackground(args,cwd=None,suppressOutput=True,collectStdout=False,collectStderr=False):
   """
   Same as subprocess.call except here you can specify the cwd.
   Returns imediately with the subprocess
   """
-  if collectOutput:
-    process = subprocess.Popen(args,cwd=cwd,stdout=subprocess.PIPE,stderr=subprocess.PIPE)
-  elif suppressOutput:
+  stdout = None
+  stderr = None
+
+  if suppressOutput:
     devnull = open(os.devnull,"a")
-    process = subprocess.Popen(args,cwd=cwd,stdout=devnull,stderr=devnull,close_fds=True)
-  else:
-    process = subprocess.Popen(args,cwd=cwd)
+    stdout = devnull
+    stderr = devnull
+
+  if collectStdout:
+    temp_stdout = tempfile.TemporaryFile()
+    stdout = temp_stdout.fileno()
+  if collectStderr:
+    temp_stderr = tempfile.TemporaryFile()
+    stderr = temp_stderr.fileno()
+
+  process = subprocess.Popen(args,cwd=cwd,stdout=stdout,stderr=stderr,close_fds=True)
+
+  if collectStdout:
+    process.stdout_file = temp_stdout
+  if collectStderr:
+    process.stderr_file = temp_stderr
+
   return process
 
 def callCollectOutput(args,cwd=None):


### PR DESCRIPTION
Like we were discussing in [my last pull request](https://github.com/subuser-security/subuser/pull/225), using pipes directly might lead to problems. Therefore, I changed the code to use temporary files instead.

In addition, I split the "collectOuput" parameter into "collectStdout" and "collectStderr", which allows us to reduce the number of temporary files created to only one (Xpra outputs to stderr). Now, "suppressOutput" is no longer unnecessary, unless collecting both Stdout and Stderr.

Lastly, I noticed that the code didn't wait for the Xpra client to initialize before launching the main app. While I never noticed any problems, they might occur on slower computers and/or under load, so I made it also wait for it to get ready ("Attached to `display name`" indicates readiness).

One thing to note, I never close the temporary files. While the garbage collector knows to close them once they drop out of scope, it might be a good idea to close the files ourselves as well, before returning from waitForContainerToLaunch.