### PR TITLE
Remove double line-break when re-printing output while waiting for containers to launch

### DIFF
--- a/logic/subuserlib/classes/subuserSubmodules/run/x11Bridge.py
+++ b/logic/subuserlib/classes/subuserSubmodules/run/x11Bridge.py
@@ -207,7 +207,7 @@ class XpraX11Bridge(Service):
         process.stderr_file.seek(where)
       else:
         if not suppressOutput:
-          print(line)
+          print(line[:-1])
         if readyString in line:
           break
     process.stderr_file.close()


### PR DESCRIPTION
Just a small fix. When you merged my pull request, I had

    print line,

That comma at the end means that print wouldn't write any line-break (`line` already contains a line-break). When you converted to the python3 compatible print statements, you forgot this, and as such it was re-printing lines with double linebreaks