### PR TITLE
Python 3 support : in Python 3, "raw_input" is now "input"

### DIFF
--- a/logic/subuserCommands/subuser-pkg.py
+++ b/logic/subuserCommands/subuser-pkg.py
@@ -12,6 +12,13 @@ import optparse
 import json
 import os
 import copy
+
+# Python 2.x/Python 3 compatibility
+try:
+    input = raw_input
+except NameError:
+    raw_input = input
+
 #internal imports
 from subuserlib.classes.user import User
 import subuserlib.commandLineArguments

--- a/logic/subuserlib/classes/permissionsAccepters/acceptPermissionsAtCLI.py
+++ b/logic/subuserlib/classes/permissionsAccepters/acceptPermissionsAtCLI.py
@@ -8,6 +8,13 @@ This is a PermissionAccepter object used to get user approval of permissions via
 
 #external imports
 from collections import OrderedDict
+
+# Python 2.x/Python 3 compatibility
+try:
+    input = raw_input
+except NameError:
+    raw_input = input
+
 #internal imports
 from subuserlib.classes.permissionsAccepters.permissionsAccepter import PermissionsAccepter
 from subuserlib.classes.userOwnedObject import UserOwnedObject


### PR DESCRIPTION
The code now tries to get "raw_input" (if successful (Python 2), it will write over "input" which was insecure anyways). If it fails (in Python 3), it will make Python 3's "input" available as "raw_input".

So this should work in both Python 2 and 3.