### PR TITLE
Add missing GitException handling (fixes #338)

### DIFF
--- a/logic/subuserlib/classes/registry.py
+++ b/logic/subuserlib/classes/registry.py
@@ -59,7 +59,10 @@ class Registry(userOwnedObject.UserOwnedObject):
       # Ensure git is setup before we start to make changes.
       self.gitRepository.assertGitSetup()
       self.user.endUser.makedirs(self.user.config["registry-dir"])
-      self.gitRepository.run(["init"])
+      try:
+        self.gitRepository.run(["init"])
+      except subuserlib.classes.gitRepository.GitException as e:
+        sys.exit("Git failed with: '%s'." % str(e).strip())
       self.logChange("Initial commit.")
       self.commit("Initial commit.",_no_lock_needed = True)
     self.initialized = True


### PR DESCRIPTION
Induce the issue:

```git config --global init.templatedir "/tmp/non-existing"```

without the fix:

```
$ rm -rf ~/.subuser && subuser list available                                                                                                                                                                      
warning: templates not found /tmp/non-existing
Traceback (most recent call last):
  File "/usr/local/bin/subuser", line 52, in <module>
    command(sys.argv[2:])
  File "/usr/local/lib/python3.5/dist-packages/subuserlib/builtInCommands/list.py", line 64, in runCommand
    reposToList = user.registry.repositories.keys()
  File "/usr/local/lib/python3.5/dist-packages/subuserlib/classes/user.py", line 70, in registry
    self.__registry.ensureGitRepoInitialized()
  File "/usr/local/lib/python3.5/dist-packages/subuserlib/classes/registry.py", line 62, in ensureGitRepoInitialized
    self.gitRepository.run(["init"])
  File "/usr/local/lib/python3.5/dist-packages/subuserlib/classes/gitRepository.py", line 60, in run
    returncode,_ = self.__run(args)
  File "/usr/local/lib/python3.5/dist-packages/subuserlib/classes/gitRepository.py", line 84, in __run
    raise GitException(stderr)
subuserlib.classes.gitRepository.GitException: warning: templates not found /tmp/non-existing
```

with the fix:

```
$ rm -rf ~/.subuser && subuser list available
warning: templates not found /tmp/non-existing
Git failed with: 'warning: templates not found /tmp/non-existing'.
```