### PR TITLE
Add "-dirty" postfix to version string for uncommitted changes

### DIFF
--- a/logic/subuserlib/classes/gitRepository.py
+++ b/logic/subuserlib/classes/gitRepository.py
@@ -128,6 +128,17 @@ $ git config --global user.email johndoe@example.com
       raise OSError("Running git in "+self.path+" with args "+str(command)+" failed.")
     return output.strip()
 
+  def doesHaveUncommittedChanges(self,ref):
+    command = ["diff-index","--name-only",ref]
+    (returncode,output) = self.runCollectOutput(command)
+    if returncode != 0:
+      # Just ignore it if command failed
+      return False
+    if output:
+      return True
+    else:
+      return False
+
 class GitFileStructure(FileStructure):
   def __init__(self,gitRepository,commit):
     """

--- a/logic/subuserlib/version.py
+++ b/logic/subuserlib/version.py
@@ -27,7 +27,10 @@ def getSubuserVersion(user):
   if os.path.exists(os.path.join(subuserlib.paths.getSubuserDir(),".git")):
     gitRepo = GitRepository(user,subuserlib.paths.getSubuserDir())
     gitHash = gitRepo.getHashOfRef("HEAD")
-    return stableVersion+"-dev-"+gitHash
+    devVersionString = stableVersion+"-dev-"+gitHash
+    if gitRepo.doesHaveUncommittedChanges("HEAD"):
+      devVersionString += "-dirty"
+    return devVersionString
   else:
     return stableVersion
 


### PR DESCRIPTION
This is inspired by Linux kernel: https://github.com/torvalds/linux/blob/b244131/scripts/setlocalversion#L76

It may be useful for multiple reasons, for example:
- if someone raises a bug, and his version has `-dirty` postfix, then the person should be asked to reproduce it on unmodified version, in order to make sure the bug is not due to local changes.

This is how it works:

```sh
$ git status
On branch mark-uncommitted-changes-in-version
Your branch is up to date with 'origin/mark-uncommitted-changes-in-version'.

nothing to commit, working tree clean
$ subuser version | head -1
Subuser version: 0.6.2-dev-825feeb812e3f75dccb6ecc339f8c68541269fe6

$ echo "" >> logic/subuserlib/version.py
$ git status
On branch mark-uncommitted-changes-in-version
Your branch is up to date with 'origin/mark-uncommitted-changes-in-version'.

Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

        modified:   logic/subuserlib/version.py

no changes added to commit (use "git add" and/or "git commit -a")
$ subuser version | head -1
Subuser version: 0.6.2-dev-825feeb812e3f75dccb6ecc339f8c68541269fe6-dirty
$ git checkout logic/subuserlib/version.py
$ subuser version | head -1
Subuser version: 0.6.2-dev-825feeb812e3f75dccb6ecc339f8c68541269fe6
```
