### PR TITLE
Use install with git checkout needs module inclusion

### DIFF
--- a/logic/subuser
+++ b/logic/subuser
@@ -4,6 +4,7 @@
 #internal imports
 import sys
 import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 import subprocess
 import getpass
 import grp


### PR DESCRIPTION
Hi,

I've checkout the master branch and followed the documentation to use the master branch instead of pip install or setup.py. I'm using Python 3.8.

> Add subuser/logic and ~/.subuser/bin to your path by adding the line PATH=$HOME/subuser/logic:$HOME/.subuser/bin:$PATH to the end of your .bashrc file.

Subuser couldn't start because it errored when including libs from subuserlib folder.

With this change, the git install works as it detects the subuserlib module.